### PR TITLE
add (require 'hl-line)

### DIFF
--- a/objed.el
+++ b/objed.el
@@ -125,6 +125,7 @@
 (require 'nadvice)
 (require 'face-remap)
 (require 'subword)
+(require 'hl-line)
 
 (require 'objed-objects)
 


### PR DESCRIPTION
Add a (require 'hl-line) in objed.el file.

Fix error if user set to **nil** line highlight using **objed-use-hl** bind.

ERROR:
```
Debugger entered--Lisp error: (void-function hl-line-highlight)
  (hl-line-highlight)
  (prog1 (cond ((commandp sym) (objed--switch-to-object-for-cmd sym)) ((symbolp sym) (objed--switch-to sym)) (t (if objed--object nil (setq objed--object (quote char))) (objed--update-current-object sym))) (hl-line-highlight) (fset (function objed--exit-objed) (set-transient-map objed-map (function objed--keep-transient-p) (function objed--reset))) (if objed-modeline-hint-p (progn (funcall objed-modeline-setup-func objed-mode-line-format))) (if objed-auto-wk-top-level-p (progn (run-at-time 0 nil (function objed-show-top-level)))))
  objed--init(char)
  (progn (objed--init (or obj objed--object (quote char))))
  (if (funcall objed-init-p-function) (progn (objed--init (or obj objed--object (quote char)))))
  objed-init()
  apply(objed-init nil)
  timer-event-handler([t 23717 3565 225098 nil objed-init nil nil 985000])

```

-------------------------
Objed: 0.8.1
Emacs 26.2 RC1 
Debian SID

