### PR TITLE
Disable during a company completion

### DIFF
--- a/objed.el
+++ b/objed.el
@@ -1299,6 +1299,8 @@ See `objed-cmd-alist'."
        (not overriding-terminal-local-map)
        ;; don't activate when completing the regular Emacs way
        (not (get-buffer-window "*Completions*" 0))
+       ;; don't activate during a company completion
+       (not (bound-and-true-p company-candidates))
        ;; FIXME: temp workaround for starting commit
        ;; message in insertion mode
        (not (eq last-command 'magit-commit-create))


### PR DESCRIPTION
When using `company-box`, documentation for the highlighted candidate is rendered in a childframe.  Objed gets activated after the documentation has rendered, despite the completion still being in progress.  This can occur while in the middle of typing, with messy consequences.

The activation seems to be due to the use of `switch-to-buffer` while rendering the documentation.