### PR TITLE
Implemented objed-local-mode

### DIFF
--- a/README.asc
+++ b/README.asc
@@ -21,11 +21,11 @@ file.
 == Introduction
 
 Text objects are textual patterns like a line, a top level definition, a word,
-a sentence or any other unit of text. When `objed-mode` is enabled, certain
-editing commands (configurable) will activate `objed` and enable its modal
-editing features. When active, keys which would usually insert a character are
-mapped to objed commands. Other keys and commands will continue to work as
-they normally would and exit this editing state again.
+a sentence or any other unit of text. When `objed-mode` or `objed-local-mode`
+is enabled, certain editing commands (configurable) will activate `objed` and
+enable its modal editing features. When active, keys which would usually insert
+a character are mapped to objed commands. Other keys and commands will continue
+to work as they normally would and exit this editing state again.
 
 By default important editing keys like kbd:[Space], kbd:[DEL] or kbd:[Return]
 are not bound to modal commands and will execute the regular command and exit
@@ -458,6 +458,7 @@ M-x package-install RET objed RET
 ;; activate objed-mode in you init
 (objed-mode)
 ```
+
 For manual installation:
 
 ```sh
@@ -473,6 +474,12 @@ Add this to your init file:
 ;; always manually using `objed-activate' the other
 ;; commands bound in `objed-mode-map`, for example:
 ;; (global-set-key (kbd "M-SPC") 'objed-activate)
+```
+
+In case you don't want to enable `objed` globally, use `objed-local-mode`:
+
+```emacs
+(add-hook 'prog-mode-hook #'objed-local-mode)
 ```
 
 == Contribute

--- a/objed.el
+++ b/objed.el
@@ -4140,12 +4140,14 @@ To define your own text objects and editing operations see
   ;; Same mechanism as in electric-{indent,layout,quote}-mode
   (cond
    ((eq objed-mode (default-value 'objed-mode))
+    ;; If the local value is set to the default value, unmark
+    ;; `objed-mode' as local
     (kill-local-variable 'objed-mode))
    ((not (default-value 'objed-mode))
-    ;; Locally enabled, but globally disabled.
-    (objed-mode 1)		      ; Setup the hooks.
-    (setq-default objed-mode nil)     ; But keep it globally disabled.
-    )))
+    ;; If `objed-mode' isn't enabled by default, enable it globally to
+    ;; invoke the setup routines, and then reset the default value
+    (objed-mode 1)
+    (setq-default objed-mode nil))))
 
 (defun objed--install-advices-for (cmds obj)
   "Given a list of commands CMDS install advices for OBJ.

--- a/objed.el
+++ b/objed.el
@@ -4134,6 +4134,18 @@ To define your own text objects and editing operations see
       ;; auto entry cmds
       (advice-remove f #'objed--init-later))))
 
+(define-minor-mode objed-local-mode
+  "Enable `objed-mode' in current buffer."
+  :variable (buffer-local-value 'objed-mode (current-buffer))
+  ;; Same mechanism as in electric-{indent,layout,quote}-mode
+  (cond
+   ((eq objed-mode (default-value 'objed-mode))
+    (kill-local-variable 'objed-mode))
+   ((not (default-value 'objed-mode))
+    ;; Locally enabled, but globally disabled.
+    (objed-mode 1)		      ; Setup the hooks.
+    (setq-default objed-mode nil)     ; But keep it globally disabled.
+    )))
 
 (defun objed--install-advices-for (cmds obj)
   "Given a list of commands CMDS install advices for OBJ.


### PR DESCRIPTION
I couldn't find any issue on this topic, so I tried to fix this myself:

I don't want objed to be enabled in every buffer, but for example only `prog-mode` and `text-mode` derived modes. This patch implements a buffer local variant of `objed-mode`, just like the electric modes do, so that I could write

~~~lisp
(add-hook 'prog-mode-hook #'objed-local-mode)
(add-hook 'text-mode-hook #'objed-local-mode)
~~~

in my configuration.

I didn't test it extensively, but everything appears to work as expected (ie. enabling and disabling `objed-local-mode` only affects the current buffer). 