### PR TITLE
Fix `wrong-type-argument symbolp`

### DIFF
--- a/objed.el
+++ b/objed.el
@@ -1340,7 +1340,9 @@ See `objed-cmd-alist'."
   "Return non-nil when any self insertion key is rebound."
   (cl-dolist (char (string-to-list "abcdefghijklmnopqrstuvwxyz"))
     (let ((binding (key-binding (vector char))))
-      (when (not (string-match "insert" (symbol-name binding)))
+      (when (not (and
+                  (symbolp binding)
+                  (string-match "insert" (symbol-name binding))))
         (cl-return binding)))))
 
 (defun objed-init-p ()


### PR DESCRIPTION
Not only symbols can be found in key bindings.